### PR TITLE
Fixes for 2.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Probe Screen V2 for LinuxCNC
 
+This version contains minor changes to make probe screen work in 2.8 (axis/joint topic)
+
  Install.
 -----------------------------------------------------------------------------
 1. Delete (or comment out) from all .hal files lines of the form:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Probe Screen V2 for LinuxCNC
 
-This version contains minor changes to make probe screen work in 2.8 (axis/joint topic)
+This version contains minor changes to make probe_screen_v2 work in 2.8 (axis/joint topic)
+Changes affect macros and probe_screen.py.
 
  Install.
 -----------------------------------------------------------------------------

--- a/macros/block_down.ngc
+++ b/macros/block_down.ngc
@@ -2,7 +2,7 @@ o<block_down> sub
 (cancel all Z offsets)
 G49
 G92.1
-G10 L20 P0  Z[#<_hal[axis.2.joint-pos-cmd]>]
+G10 L20 P0  Z[#<_hal[axis.z.pos-cmd]>]
 
 G91
 F #<_hal[probe.ps_searchvel]>

--- a/macros/gotots.ngc
+++ b/macros/gotots.ngc
@@ -1,6 +1,6 @@
 o<gotots> sub
 F#<_ini[TOOLSENSOR]RAPID_SPEED>
-G53 G1 Z[#<_ini[AXIS_2]MAX_LIMIT>]
+G53 G1 Z[#<_ini[AXIS_Z]MAX_LIMIT>]
 G53 G1 X[#<_ini[TOOLSENSOR]X>] Y[#<_ini[TOOLSENSOR]Y>]
 G53 G1 Z[#<_ini[TOOLSENSOR]Z>]
 

--- a/macros/manual_change.ngc
+++ b/macros/manual_change.ngc
@@ -17,7 +17,8 @@ O100     return [999]
 O100 endif
 
 ;first go up
-G53 G0 Z[#<_ini[AXIS_2]MAX_LIMIT>-0.1]
+G90
+G53 G0 Z[#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 ; then move to change position
 G53 G0 X[#<_ini[CHANGE_POSITION]X>] Y[#<_ini[CHANGE_POSITION]Y>]
 G53 G0 Z[#<_ini[CHANGE_POSITION]Z>]
@@ -46,10 +47,11 @@ O400 endif
 F #<_hal[probe.ps_searchvel]>
 G91
 G38.2 Z #<_ini[TOOLSENSOR]MAXPROBE>
-G0 Z0.26
+G38.4 Z2
+;G1 Z0.5
 ; This is commented out only for sim.
 F #<_hal[probe.ps_probevel]>
-G38.2 Z-0.5
+G38.2 Z-2
 
 O500 if [#5070 EQ 0]
 G90

--- a/macros/probe_down.ngc
+++ b/macros/probe_down.ngc
@@ -1,12 +1,13 @@
 o<probe_down> sub
 F#<_ini[TOOLSENSOR]RAPID_SPEED>
-G53 G1 Z[#<_ini[AXIS_2]MAX_LIMIT>-0.1]
+G90
+G53 G1 Z[#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 G53 G1 X[#<_ini[TOOLSENSOR]X>] Y[#<_ini[TOOLSENSOR]Y>]
 G53 G1 Z[#<_ini[TOOLSENSOR]Z>]
 (cancel all Z offsets)
 G92.1
 G49
-G10 L20 P0  Z[#<_hal[axis.2.joint-pos-cmd]>]
+G10 L20 P0  Z[#<_hal[axis.z.pos-cmd]>]
 
 G91
 F #<_hal[probe.ps_searchvel]>

--- a/python/probe_screen.py
+++ b/python/probe_screen.py
@@ -385,7 +385,8 @@ class ProbeScreenClass:
             direction = 1
         else:
             direction = -1
-        jjogmode=True 
+        jjogmode=True
+        self.command.teleop_enable(0) 
         if self.distance <> 0:  # incremental jogging
             self.command.jog( linuxcnc.JOG_INCREMENT , jjogmode , axisnumber , direction * velocity , self.distance )
         else:  # continuous jogging
@@ -398,7 +399,7 @@ class ProbeScreenClass:
             return
         jjogmode=True
         axisnumber = "xyzabcuvw".index( axisletter.lower() )
-
+        self.command.teleop_enable(0)
         if self.distance <> 0:
             pass
         else:

--- a/python/probe_screen.py
+++ b/python/probe_screen.py
@@ -2015,7 +2015,7 @@ class ProbeScreenClass:
             self.warning_dialog( self, _( "Conversion error in btn_block_height!" ),
                                    _( "Please enter only numerical values\nValues have not been applied" ) )
         # set koordinate system to new origin
-        origin = float(self.inifile.find("AXIS_2", "MIN_LIMIT")) + blockheight
+        origin = float(self.inifile.find("AXIS_Z", "MIN_LIMIT")) + blockheight
         self.command.mode( linuxcnc.MODE_MDI )
         self.command.wait_complete()
         self.command.mdi( "G10 L2 P0 Z%s" % origin )

--- a/python/probe_screen.py
+++ b/python/probe_screen.py
@@ -379,32 +379,30 @@ class ProbeScreenClass:
             value = 0.2
         else:
             value = 1
-
-        velocity = float(self.inifile.find("TRAJ", "DEFAULT_VELOCITY"))
-
+        velocity = int(self.inifile.find("TRAJ", "DEFAULT_LINEAR_VELOCITY"))
         dir = widget.get_label()[1]
         if dir == "+":
             direction = 1
         else:
             direction = -1
-
+        jjogmode=True 
         if self.distance <> 0:  # incremental jogging
-            self.command.jog( linuxcnc.JOG_INCREMENT, axisnumber, direction * velocity, self.distance )
+            self.command.jog( linuxcnc.JOG_INCREMENT , jjogmode , axisnumber , direction * velocity , self.distance )
         else:  # continuous jogging
-            self.command.jog( linuxcnc.JOG_CONTINUOUS, axisnumber, direction * velocity )
+            self.command.jog( linuxcnc.JOG_CONTINUOUS , jjogmode, axisnumber , direction * velocity )
 
     def on_btn_jog_released( self, widget, data = None ):
         axisletter = widget.get_label()[0]
         if not axisletter.lower() in "xyzabcuvw":
             print ( "unknown axis %s" % axisletter )
             return
-
-        axis = "xyzabcuvw".index( axisletter.lower() )
+        jjogmode=True
+        axisnumber = "xyzabcuvw".index( axisletter.lower() )
 
         if self.distance <> 0:
             pass
         else:
-            self.command.jog( linuxcnc.JOG_STOP, axis )
+            self.command.jog( linuxcnc.JOG_STOP, jjogmode, axisnumber )
 
 
     # Spin  buttons


### PR DESCRIPTION
Dear all,

further bugs were found during testing. With the intergation of teleop_enable(0) jogging now works in both referenced as well as not referenced state by using jjogmode=True.